### PR TITLE
Thread-safe dictionaries

### DIFF
--- a/src/Dapper.FluentMap-net35/Dapper.FluentMap-net35.csproj
+++ b/src/Dapper.FluentMap-net35/Dapper.FluentMap-net35.csproj
@@ -38,6 +38,10 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Threading, Version=1.0.2856.102, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\TaskParallelLibrary.1.0.2856.0\lib\Net35\System.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Dapper.FluentMap\Configuration\FluentConventionConfiguration.cs">

--- a/src/Dapper.FluentMap-net35/packages.config
+++ b/src/Dapper.FluentMap-net35/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Dapper" version="1.38" targetFramework="net35" />
+  <package id="TaskParallelLibrary" version="1.0.2856.0" targetFramework="net35" />
 </packages>

--- a/src/Dapper.FluentMap/Configuration/FluentMapConfiguration.cs
+++ b/src/Dapper.FluentMap/Configuration/FluentMapConfiguration.cs
@@ -17,8 +17,8 @@ namespace Dapper.FluentMap.Configuration
         /// <param name="mapper">An instance of the <see cref="T:Dapper.FluentMap.Mapping.IEntityMap"/> interface containing the entity mapping configuration.</param>
         public void AddMap<TEntity>(IEntityMap<TEntity> mapper) where TEntity : class
         {
-            FluentMapper.EntityMaps.TryAdd(typeof (TEntity), mapper);
-            FluentMapper.AddTypeMap<TEntity>();
+            if (FluentMapper.EntityMaps.TryAdd(typeof (TEntity), mapper))
+                FluentMapper.AddTypeMap<TEntity>();
         }
 
         /// <summary>

--- a/src/Dapper.FluentMap/Configuration/FluentMapConfiguration.cs
+++ b/src/Dapper.FluentMap/Configuration/FluentMapConfiguration.cs
@@ -17,7 +17,7 @@ namespace Dapper.FluentMap.Configuration
         /// <param name="mapper">An instance of the <see cref="T:Dapper.FluentMap.Mapping.IEntityMap"/> interface containing the entity mapping configuration.</param>
         public void AddMap<TEntity>(IEntityMap<TEntity> mapper) where TEntity : class
         {
-            FluentMapper.EntityMaps.Add(typeof (TEntity), mapper);
+            FluentMapper.EntityMaps.TryAdd(typeof (TEntity), mapper);
             FluentMapper.AddTypeMap<TEntity>();
         }
 

--- a/src/Dapper.FluentMap/FluentMapper.cs
+++ b/src/Dapper.FluentMap/FluentMapper.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using Dapper.FluentMap.Configuration;
 using Dapper.FluentMap.Conventions;
@@ -17,7 +18,7 @@ namespace Dapper.FluentMap
         /// <summary>
         /// Gets the dictionary containing the entity mapping per entity type.
         /// </summary>
-        public static readonly IDictionary<Type, IEntityMap> EntityMaps = new Dictionary<Type, IEntityMap>();
+        public static readonly ConcurrentDictionary<Type, IEntityMap> EntityMaps = new ConcurrentDictionary<Type, IEntityMap>();
 
         /// <summary>
         /// Gets the dictionairy containing the conventions per entity type.

--- a/src/Dapper.FluentMap/TypeMaps/FluentConventionTypeMap.cs
+++ b/src/Dapper.FluentMap/TypeMaps/FluentConventionTypeMap.cs
@@ -59,13 +59,13 @@ namespace Dapper.FluentMap.TypeMaps
                     }
 
                     info = maps[0].PropertyInfo;
-                    TypePropertyMapCache.Add(cacheKey, info);
+                    TypePropertyMapCache.TryAdd(cacheKey, info);
                     return info;
                 }
             }
 
             // If we get here, the property was not mapped.
-            TypePropertyMapCache.Add(cacheKey, null);
+            TypePropertyMapCache.TryAdd(cacheKey, null);
             return null;
         }
 

--- a/src/Dapper.FluentMap/TypeMaps/FluentTypeMap.cs
+++ b/src/Dapper.FluentMap/TypeMaps/FluentTypeMap.cs
@@ -45,14 +45,14 @@ namespace Dapper.FluentMap.TypeMaps
                 {
                     if (!propertyMap.Ignored)
                     {
-                        TypePropertyMapCache.Add(cacheKey, propertyMap.PropertyInfo);
+                        TypePropertyMapCache.TryAdd(cacheKey, propertyMap.PropertyInfo);
                         return propertyMap.PropertyInfo;
                     }
                 }
             }
 
             // If we get here, the property was not mapped.
-            TypePropertyMapCache.Add(cacheKey, null);
+            TypePropertyMapCache.TryAdd(cacheKey, null);
             return null;
         }
 

--- a/src/Dapper.FluentMap/TypeMaps/MultiTypeMap.cs
+++ b/src/Dapper.FluentMap/TypeMaps/MultiTypeMap.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -10,7 +11,7 @@ namespace Dapper.FluentMap.TypeMaps
     internal abstract class MultiTypeMap : SqlMapper.ITypeMap
     {
         private readonly IEnumerable<SqlMapper.ITypeMap> _mappers;
-        private static readonly Dictionary<string, PropertyInfo> _typePropertyMapCache = new Dictionary<string, PropertyInfo>();
+        private static readonly ConcurrentDictionary<string, PropertyInfo> _typePropertyMapCache = new ConcurrentDictionary<string, PropertyInfo>();
 
         /// <summary>
         /// Initializes an instance of the <see cref="T:Dapper.FluentMap.TypeMaps.MultiTypeMap"/> 
@@ -112,7 +113,7 @@ namespace Dapper.FluentMap.TypeMaps
             return null;
         }
 
-        protected static Dictionary<string, PropertyInfo> TypePropertyMapCache
+        protected static ConcurrentDictionary<string, PropertyInfo> TypePropertyMapCache
         {
             get
             {


### PR DESCRIPTION
It happens that registering new type can happens simultaneously when used in async methods. Under heavy load exception are thrown because of different threads trying to add to TypePropertyMapCache. 
Same thing happens sometimes with FluentMapper.EntityMaps dictionary when key added simultaneously by more than one thread. 