### PR TITLE
Upgraded Dapper.FluentMap.Dommel to support Dommel v2

### DIFF
--- a/Dapper.FluentMap.sln
+++ b/Dapper.FluentMap.sln
@@ -1,7 +1,6 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26114.2
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{580E3446-6579-4414-9875-970849E635E5}"
 EndProject
@@ -12,11 +11,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{742442F2-CAE7-4DC8-BD73-8C54C0005A53}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper.FluentMap", "src\Dapper.FluentMap\Dapper.FluentMap.csproj", "{457E0B9B-F6A4-42C6-BFAE-6F8C71D1F435}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.FluentMap", "src\Dapper.FluentMap\Dapper.FluentMap.csproj", "{457E0B9B-F6A4-42C6-BFAE-6F8C71D1F435}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper.FluentMap.Tests", "test\Dapper.FluentMap.Tests\Dapper.FluentMap.Tests.csproj", "{8901F2FD-F98B-484B-A20A-7844A39C7458}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.FluentMap.Tests", "test\Dapper.FluentMap.Tests\Dapper.FluentMap.Tests.csproj", "{8901F2FD-F98B-484B-A20A-7844A39C7458}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper.FluentMap.Dommel", "src\Dapper.FluentMap.Dommel\Dapper.FluentMap.Dommel.csproj", "{E60B79F6-FE71-44E0-BE88-BFA269378EDB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Dapper.FluentMap.Dommel", "src\Dapper.FluentMap.Dommel\Dapper.FluentMap.Dommel.csproj", "{E60B79F6-FE71-44E0-BE88-BFA269378EDB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Dapper.FluentMap.Dommel.Tests", "test\Dapper.FluentMap.Dommel.Tests\Dapper.FluentMap.Dommel.Tests.csproj", "{DFB62D87-9A74-40DF-A930-8F61A53E0F1B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -36,6 +37,10 @@ Global
 		{E60B79F6-FE71-44E0-BE88-BFA269378EDB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E60B79F6-FE71-44E0-BE88-BFA269378EDB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E60B79F6-FE71-44E0-BE88-BFA269378EDB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFB62D87-9A74-40DF-A930-8F61A53E0F1B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFB62D87-9A74-40DF-A930-8F61A53E0F1B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFB62D87-9A74-40DF-A930-8F61A53E0F1B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFB62D87-9A74-40DF-A930-8F61A53E0F1B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -44,5 +49,9 @@ Global
 		{457E0B9B-F6A4-42C6-BFAE-6F8C71D1F435} = {580E3446-6579-4414-9875-970849E635E5}
 		{8901F2FD-F98B-484B-A20A-7844A39C7458} = {742442F2-CAE7-4DC8-BD73-8C54C0005A53}
 		{E60B79F6-FE71-44E0-BE88-BFA269378EDB} = {580E3446-6579-4414-9875-970849E635E5}
+		{DFB62D87-9A74-40DF-A930-8F61A53E0F1B} = {742442F2-CAE7-4DC8-BD73-8C54C0005A53}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {10834736-59FD-47FF-9344-096247DC48CD}
 	EndGlobalSection
 EndGlobal

--- a/src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj
+++ b/src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj
@@ -2,17 +2,20 @@
   <PropertyGroup>
     <Description>Dapper.FluentMap extension for Dommel support.</Description>
     <Copyright>Copyright © Henk Mollema 2017</Copyright>
-    <VersionPrefix>1.7.0</VersionPrefix>
+    <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Henk Mollema</Authors>
-    <TargetFrameworks>net451;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>dapper;fluentmap;dommel</PackageTags>
     <PackageProjectUrl>https://github.com/henkmollema/Dapper-FluentMap</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/henkmollema/Dapper-FluentMap/blob/master/LICENSE</PackageLicenseUrl>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+    <Version>2.0.0-alpha2</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dapper.FluentMap\Dapper.FluentMap.csproj" />
-    <PackageReference Include="Dapper" Version="1.60.6" />
-    <PackageReference Include="Dommel" Version="1.11.0" />
+    <PackageReference Include="Dapper" Version="2.0.30" />
+    <PackageReference Include="Dommel" Version="2.0.0-beta6" />
   </ItemGroup>
 </Project>

--- a/src/Dapper.FluentMap.Dommel/Resolvers/DommelColumnNameResolver.cs
+++ b/src/Dapper.FluentMap.Dommel/Resolvers/DommelColumnNameResolver.cs
@@ -11,6 +11,8 @@ namespace Dapper.FluentMap.Dommel.Resolvers
     /// </summary>
     public class DommelColumnNameResolver : DommelMapper.IColumnNameResolver
     {
+        private readonly DommelMapper.IColumnNameResolver DefaultResolver = new DommelMapper.DefaultColumnNameResolver();
+
         /// <inheritdoc/>
         public string ResolveColumnName(PropertyInfo propertyInfo)
         {
@@ -36,7 +38,7 @@ namespace Dapper.FluentMap.Dommel.Resolvers
                 }
             }
 
-            return DommelMapper.Resolvers.Default.ColumnNameResolver.ResolveColumnName(propertyInfo);
+            return DefaultResolver.ResolveColumnName(propertyInfo);
         }
     }
 }

--- a/src/Dapper.FluentMap.Dommel/Resolvers/DommelPropertyResolver.cs
+++ b/src/Dapper.FluentMap.Dommel/Resolvers/DommelPropertyResolver.cs
@@ -10,8 +10,10 @@ namespace Dapper.FluentMap.Dommel.Resolvers
     /// <summary>
     /// Implements the <see cref="DommelMapper.IPropertyResolver"/> interface by using the configured mapping.
     /// </summary>
-    public class DommelPropertyResolver : DommelMapper.PropertyResolverBase
+    public class DommelPropertyResolver : DommelMapper.DefaultPropertyResolver
     {
+        private readonly DommelMapper.IPropertyResolver DefaultResolver = new DommelMapper.DefaultPropertyResolver();
+
         /// <inheritdoc/>
         protected override IEnumerable<PropertyInfo> FilterComplexTypes(IEnumerable<PropertyInfo> properties)
         {
@@ -45,7 +47,7 @@ namespace Dapper.FluentMap.Dommel.Resolvers
             }
             else
             {
-                foreach (var property in DommelMapper.Resolvers.Default.PropertyResolver.ResolveProperties(type))
+                foreach (var property in DefaultResolver.ResolveProperties(type))
                 {
                     yield return property;
                 }

--- a/src/Dapper.FluentMap.Dommel/Resolvers/DommelTableNameResolver.cs
+++ b/src/Dapper.FluentMap.Dommel/Resolvers/DommelTableNameResolver.cs
@@ -10,6 +10,8 @@ namespace Dapper.FluentMap.Dommel.Resolvers
     /// </summary>
     public class DommelTableNameResolver : DommelMapper.ITableNameResolver
     {
+        private readonly DommelMapper.ITableNameResolver DefaultResolver = new DommelMapper.DefaultTableNameResolver();
+
         /// <inheritdoc />
         public string ResolveTableName(Type type)
         {
@@ -24,7 +26,7 @@ namespace Dapper.FluentMap.Dommel.Resolvers
                 }
             }
 
-            return DommelMapper.Resolvers.Default.TableNameResolver.ResolveTableName(type);
+            return DefaultResolver.ResolveTableName(type);
         }
     }
 }

--- a/test/Dapper.FluentMap.Dommel.Tests/Dapper.FluentMap.Dommel.Tests.csproj
+++ b/test/Dapper.FluentMap.Dommel.Tests/Dapper.FluentMap.Dommel.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net461;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="coverlet.collector" Version="1.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Dapper.FluentMap.Dommel\Dapper.FluentMap.Dommel.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Dapper.FluentMap.Dommel.Tests/ManualMappingTests.cs
+++ b/test/Dapper.FluentMap.Dommel.Tests/ManualMappingTests.cs
@@ -1,0 +1,95 @@
+using Dapper.FluentMap.Dommel.Mapping;
+using System;
+using System.Linq;
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]
+namespace Dapper.FluentMap.Dommel.Tests
+{
+    public class ManualMappingTests
+    {
+        [Fact]
+        public void EntityMapsCustomIdAsKey()
+        {
+            PreTest();
+
+            FluentMapper.Initialize(c => c.AddMap(new MapWithCustomIdPropertyMap()));
+
+            var type = typeof(CustomIdEntity);
+            var keyResolver = new Dommel.Resolvers.DommelKeyPropertyResolver();
+            var columnResolver = new Dommel.Resolvers.DommelColumnNameResolver();
+
+            var keys = keyResolver.ResolveKeyProperties(type);
+            var columnName = columnResolver.ResolveColumnName(keys.Single().Property);
+            
+            Assert.Single(keys);
+            Assert.Equal("customid", columnName);
+        }
+
+        [Fact]
+        public void EntityMapsToSingleCustomId()
+        {
+            PreTest();
+
+            FluentMapper.Initialize(c => c.AddMap(new MapSingleCustomIdPropertyMap()));
+
+            var type = typeof(DoubleIdEntity);
+            var keyResolver = new Dommel.Resolvers.DommelKeyPropertyResolver();
+            var columnResolver = new Dommel.Resolvers.DommelColumnNameResolver();
+            FluentMapper.EntityMaps.TryGetValue(type, out var entityMap);
+
+            var keys = keyResolver.ResolveKeyProperties(type);
+            var columnName = columnResolver.ResolveColumnName(keys.Single().Property);
+
+            var idName = columnResolver.ResolveColumnName(entityMap.PropertyMaps.Single(x => x.PropertyInfo.Name == nameof(DoubleIdEntity.Id)).PropertyInfo);
+
+            Assert.Single(keys);
+            Assert.Equal("id", columnName);
+            Assert.Equal("Id", idName);
+        }
+
+        [Fact]
+        public void EntityMapsToDefaultSingleKey()
+        {
+            PreTest();
+
+            FluentMapper.Initialize(c => c.AddMap(new MapSingleCustomIdDefaultKey()));
+
+            var type = typeof(DoubleIdEntity);
+            var keyResolver = new Dommel.Resolvers.DommelKeyPropertyResolver();
+            var keys = keyResolver.ResolveKeyProperties(type);
+            Assert.Single(keys);
+        }
+
+        private static void PreTest()
+        {
+            FluentMapper.EntityMaps.Clear();
+            FluentMapper.TypeConventions.Clear();
+        }
+
+        private class MapWithCustomIdPropertyMap : DommelEntityMap<CustomIdEntity>
+        {
+            public MapWithCustomIdPropertyMap()
+            {
+                Map(p => p.CustomId).IsKey().ToColumn("customid");
+            }
+        }
+
+        private class MapSingleCustomIdPropertyMap : DommelEntityMap<DoubleIdEntity>
+        {
+            public MapSingleCustomIdPropertyMap()
+            {
+                Map(p => p.Id);
+                Map(p => p.CustomId).IsKey().ToColumn("id", false);
+            }
+        }
+
+        private class MapSingleCustomIdDefaultKey : DommelEntityMap<DoubleIdEntity>
+        {
+            public MapSingleCustomIdDefaultKey()
+            {
+                Map(p => p.CustomId).ToColumn("customid", false);
+            }
+        }
+    }
+}

--- a/test/Dapper.FluentMap.Dommel.Tests/TestEntity.cs
+++ b/test/Dapper.FluentMap.Dommel.Tests/TestEntity.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Dapper.FluentMap.Dommel.Tests
+{
+    public class TestEntity
+    {
+        public int Id { get; set; }
+
+        public int? OtherId { get; set; }
+    }
+
+    public class CustomIdEntity
+    {
+        public int CustomId { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class DoubleIdEntity
+    {
+        public int Id { get; set; }
+        public int CustomId { get; set; }
+        public string Name { get; set; }
+    }
+
+    public class Other
+    {
+        public int Id { get; set; }
+    }
+}


### PR DESCRIPTION
Upgraded to support Dommel version 2.  Also added in tests for Dommel FluentMapping.
#99 resolves the conflict with the unrelated package Dapper.Dommel.