### PR TITLE
Dapper.FluentMap v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,15 @@ Provides a simple API to fluently map POCO properties to database columns when u
 
 This [Dapper](https://github.com/StackExchange/dapper-dot-net) extension allows you to fluently configure the mapping between POCO properties and database columns. This keeps your POCO's clean of mapping attributes. The functionality is similar to [Entity Framework Fluent API](http://msdn.microsoft.com/nl-nl/data/jj591617.aspx). If you have any questions, suggestions or bugs, please don't hesitate to [contact me](mailto:henkmollema@gmail.com) or create an issue.
 
-<hr>
-
 ## Download
 Dapper.FluentMap is available on [NuGet](https://www.nuget.org/packages/Dapper.FluentMap).
 
 Using the .NET Core CLI:
-#### `dotnet add package Dapper.FluentMap`
+
+`dotnet add package Dapper.FluentMap`
 
 Using the NuGet Package Manager:
-#### `PM> Install-Package Dapper.FluentMap`
+`PM> Install-Package Dapper.FluentMap`
 
 ## Usage
 ### Configuration
@@ -131,9 +130,11 @@ Dommel contains a set of extensions methods providing easy CRUD operations using
 Dapper.FluentMap is available on [NuGet](https://www.nuget.org/packages/Dapper.FluentMap.Dommel).
 
 Using the .NET Core CLI:
+
 `dotnet add package Dapper.FluentMap.Dommel`
 
 Using the NuGet Package Manager:
+
 `PM> Install-Package Dapper.FluentMap.Dommel`
 
 #### Usage

--- a/src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj
+++ b/src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj
@@ -12,7 +12,7 @@
     <PackageLicenseUrl>https://github.com/henkmollema/Dapper-FluentMap/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dommel" Version="2.0.0-beta6" />
+    <PackageReference Include="Dommel" Version="2.0.0-beta7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dapper.FluentMap\Dapper.FluentMap.csproj" />

--- a/src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj
+++ b/src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj
@@ -13,6 +13,5 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Dapper.FluentMap\Dapper.FluentMap.csproj" />
-    <PackageReference Include="Dommel" Version="2.0.0-beta3" />
   </ItemGroup>
 </Project>

--- a/src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj
+++ b/src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj
@@ -4,7 +4,7 @@
     <Copyright>Copyright © Henk Mollema 2018</Copyright>
     <VersionPrefix>2.0.0-beta2</VersionPrefix>
     <Authors>Henk Mollema</Authors>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>true</WarningsAsErrors>
     <PackageTags>dapper;fluentmap;dommel</PackageTags>

--- a/src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj
+++ b/src/Dapper.FluentMap.Dommel/Dapper.FluentMap.Dommel.csproj
@@ -12,6 +12,9 @@
     <PackageLicenseUrl>https://github.com/henkmollema/Dapper-FluentMap/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Dommel" Version="2.0.0-beta6" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Dapper.FluentMap\Dapper.FluentMap.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Dapper.FluentMap.Dommel/Mapping/DommelPropertyMap.cs
+++ b/src/Dapper.FluentMap.Dommel/Mapping/DommelPropertyMap.cs
@@ -22,11 +22,39 @@ namespace Dapper.FluentMap.Dommel.Mapping
         public bool Key { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the current property is considered a identity property.
+        /// </summary>
+        public bool Identity { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a value indicating whether the current property is considered a computed property.
+        /// </summary>
+        public bool Computed { get; set; }
+
+        /// <summary>
         /// Marks the property as a key property.
         /// </summary>
         public DommelPropertyMap IsKey()
         {
             Key = true;
+            return this;
+        }
+        
+        /// <summary>
+        /// Marks the property as a key property.
+        /// </summary>
+        public DommelPropertyMap IsIdentity()
+        {
+            Identity = true;
+            return this;
+        }
+        
+        /// <summary>
+        /// Marks the property as a computed property.
+        /// </summary>
+        public DommelPropertyMap IsComputed()
+        {
+            Computed = true;
             return this;
         }
     }
@@ -44,6 +72,32 @@ namespace Dapper.FluentMap.Dommel.Mapping
             if (propertyMapping is DommelPropertyMap dommelPropertyMapping)
             {
                 dommelPropertyMapping.IsKey();
+            }
+
+            return propertyMapping;
+        }
+        
+        /// <summary>
+        /// Marks the property as a identity property.
+        /// </summary>
+        public static PropertyMap IsIdentity(this PropertyMap propertyMapping)
+        {
+            if (propertyMapping is DommelPropertyMap dommelPropertyMapping)
+            {
+                dommelPropertyMapping.IsIdentity();
+            }
+
+            return propertyMapping;
+        }
+        
+        /// <summary>
+        /// Marks the property as a computed property.
+        /// </summary>
+        public static PropertyMap IsComputed(this PropertyMap propertyMapping)
+        {
+            if (propertyMapping is DommelPropertyMap dommelPropertyMapping)
+            {
+                dommelPropertyMapping.IsComputed();
             }
 
             return propertyMapping;

--- a/src/Dapper.FluentMap.Dommel/Resolvers/DommelColumnNameResolver.cs
+++ b/src/Dapper.FluentMap.Dommel/Resolvers/DommelColumnNameResolver.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using Dommel;
+using System.Linq;
 using System.Reflection;
 using static Dommel.DommelMapper;
 

--- a/src/Dapper.FluentMap.Dommel/Resolvers/DommelKeyPropertyResolver.cs
+++ b/src/Dapper.FluentMap.Dommel/Resolvers/DommelKeyPropertyResolver.cs
@@ -16,7 +16,7 @@ namespace Dapper.FluentMap.Dommel.Resolvers
         private static readonly DefaultKeyPropertyResolver _defaultKeyPropertyResolver = new DefaultKeyPropertyResolver();
 
         /// <inheritdoc/>
-        public KeyPropertyInfo[] ResolveKeyProperties(Type type)
+        public ColumnPropertyInfo[] ResolveKeyProperties(Type type)
         {
             if (FluentMapper.Configuration.EntityMaps.TryGetValue(type, out var entityMap))
             {
@@ -30,13 +30,13 @@ namespace Dapper.FluentMap.Dommel.Resolvers
                     {
                         if (m.Identity)
                         {
-                            return new KeyPropertyInfo(m.PropertyInfo, DatabaseGeneratedOption.Identity);
+                            return new ColumnPropertyInfo(m.PropertyInfo, DatabaseGeneratedOption.Identity);
                         }
                         if (m.Computed)
                         {
-                            return new KeyPropertyInfo(m.PropertyInfo, DatabaseGeneratedOption.Computed);
+                            return new ColumnPropertyInfo(m.PropertyInfo, DatabaseGeneratedOption.Computed);
                         }
-                        return new KeyPropertyInfo(m.PropertyInfo);
+                        return new ColumnPropertyInfo(m.PropertyInfo);
                     })
                     .ToArray();
                 }

--- a/src/Dapper.FluentMap.Dommel/Resolvers/DommelPropertyResolver.cs
+++ b/src/Dapper.FluentMap.Dommel/Resolvers/DommelPropertyResolver.cs
@@ -1,5 +1,8 @@
-﻿using System;
+﻿using Dapper.FluentMap.Dommel.Mapping;
+using Dommel;
+using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
 using static Dommel.DommelMapper;
@@ -14,17 +17,32 @@ namespace Dapper.FluentMap.Dommel.Resolvers
         private static readonly DefaultPropertyResolver _defaultPropertyResolver = new DefaultPropertyResolver();
 
         /// <inheritdoc/>
-        public IEnumerable<PropertyInfo> ResolveProperties(Type type)
+        public IEnumerable<ColumnPropertyInfo> ResolveProperties(Type type)
         {
             if (FluentMapper.Configuration.EntityMaps.TryGetValue(type, out var entityMap))
             {
-                foreach (var property in _defaultPropertyResolver.ResolveProperties(type))
+                foreach (var columnPropertyInfo in _defaultPropertyResolver.ResolveProperties(type))
                 {
+                    var propertyMap = entityMap.PropertyMaps.FirstOrDefault(p => p.PropertyInfo.Name == columnPropertyInfo.Property.Name);
+
+                    // Determine whether the property is generated
+                    var generatedOption = DatabaseGeneratedOption.None;
+                    if (propertyMap is DommelPropertyMap dommelProperyMap)
+                    {
+                        if (dommelProperyMap.Identity)
+                        {
+                            generatedOption = DatabaseGeneratedOption.Identity;
+                        }
+                        else if (dommelProperyMap.Computed)
+                        {
+                            generatedOption = DatabaseGeneratedOption.Computed;
+                        }
+                    }
+
                     // Determine whether the property should be ignored.
-                    var propertyMap = entityMap.PropertyMaps.FirstOrDefault(p => p.PropertyInfo.Name == property.Name);
                     if (propertyMap == null || !propertyMap.Ignored)
                     {
-                        yield return property;
+                        yield return new ColumnPropertyInfo(columnPropertyInfo.Property, generatedOption);
                     }
                 }
             }

--- a/src/Dapper.FluentMap.Dommel/Resolvers/DommelTableNameResolver.cs
+++ b/src/Dapper.FluentMap.Dommel/Resolvers/DommelTableNameResolver.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Dapper.FluentMap.Dommel.Mapping;
+using Dommel;
 using static Dommel.DommelMapper;
 
 namespace Dapper.FluentMap.Dommel.Resolvers

--- a/src/Dapper.FluentMap/Dapper.FluentMap.csproj
+++ b/src/Dapper.FluentMap/Dapper.FluentMap.csproj
@@ -4,7 +4,7 @@
     <Copyright>Copyright © Henk Mollema 2018</Copyright>
     <VersionPrefix>2.0.0-beta2</VersionPrefix>
     <Authors>Henk Mollema</Authors>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>true</WarningsAsErrors>
     <PackageTags>c#;dapper;mapping;fluentmap</PackageTags>
@@ -12,6 +12,6 @@
     <PackageLicenseUrl>https://github.com/henkmollema/Dapper-FluentMap/blob/master/LICENSE</PackageLicenseUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Dapper" Version="1.50.5" />
+    <PackageReference Include="Dapper" Version="2.0.30" />
   </ItemGroup>
 </Project>

--- a/src/Dapper.FluentMap/Dapper.FluentMap.csproj
+++ b/src/Dapper.FluentMap/Dapper.FluentMap.csproj
@@ -13,5 +13,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.30" />
+    <PackageReference Include="Dommel" Version="2.0.0-beta6" />
   </ItemGroup>
 </Project>

--- a/src/Dapper.FluentMap/Dapper.FluentMap.csproj
+++ b/src/Dapper.FluentMap/Dapper.FluentMap.csproj
@@ -13,6 +13,5 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.30" />
-    <PackageReference Include="Dommel" Version="2.0.0-beta6" />
   </ItemGroup>
 </Project>

--- a/test/Dapper.FluentMap.Dommel.Tests/DommelExtensionsTests.cs
+++ b/test/Dapper.FluentMap.Dommel.Tests/DommelExtensionsTests.cs
@@ -19,7 +19,9 @@ namespace Dapper.FluentMap.Dommel.Tests
                 builder.ToTable("test");
                 builder.Map(p => p.Id)
                     .ToColumn("id")
-                    .IsKey();
+                    .IsKey()
+                    .IsIdentity()
+                    .IsComputed();
             });
 
             // Assert
@@ -51,6 +53,8 @@ namespace Dapper.FluentMap.Dommel.Tests
             var dommelPropertyMapping = Assert.IsType<DommelPropertyMap>(propertyMapping);
             Assert.Equal("id", dommelPropertyMapping.ColumnName);
             Assert.True(dommelPropertyMapping.Key);
+            Assert.True(dommelPropertyMapping.Identity);
+            Assert.True(dommelPropertyMapping.Computed);
             Assert.Equal(typeof(TestEntity).GetProperty("Id"), dommelPropertyMapping.PropertyInfo);
         }
     }
@@ -62,7 +66,9 @@ namespace Dapper.FluentMap.Dommel.Tests
             ToTable("test");
             Map(p => p.Id)
                 .ToColumn("id")
-                .IsKey();
+                .IsKey()
+                .IsIdentity()
+                .IsComputed();
         }
     }
 

--- a/test/Dapper.FluentMap.Tests/Dapper.FluentMap.Tests.csproj
+++ b/test/Dapper.FluentMap.Tests/Dapper.FluentMap.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0;netcoreapp2.1;netcoreapp3.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
- Upgrade Dapper to v2.
- Upgrade Dommel to beta6.
- Implement latest IKeyPropertyResolver (support KeyPropertyInfo).
- Add IsComputed IsIdentity to DommelPropertyMap.
- Update README by refactoring and adding v2 features docs such as inline configuration and IsComputed IsIdentity methods.