### PR TITLE
Discovering IEntityMap<> implementations dynamically

### DIFF
--- a/src/Dapper.FluentMap/Utils/FluentMapConfigurationExtensions.cs
+++ b/src/Dapper.FluentMap/Utils/FluentMapConfigurationExtensions.cs
@@ -19,16 +19,19 @@ namespace Dapper.FluentMap.Utils
         /// </summary>
         /// <param name="configuration">The <see cref="FluentMapConfiguration"/> instance.</param>
         /// <param name="assemblies">The assemblies to scan for entity maps.</param>
-        /// <exception cref="ArgumentNullException"></exception>
         public static void ApplyMapsFromAssemblies(this FluentMapConfiguration configuration,  params Assembly[] assemblies)
         {
             if (assemblies == null)
+            {
                 throw new ArgumentNullException(nameof(assemblies));
+            }
 
             var entityMapTypes = FindTypesImplementingIEntityMap(assemblies);
 
             if (!entityMapTypes.Any())
+            {
                 return;
+            }
 
             EnsureNoDuplicateMapping(entityMapTypes);
 
@@ -75,9 +78,11 @@ namespace Dapper.FluentMap.Utils
                                    $"Cannot find {nameof(configuration.AddMap)} method on {configuration.GetType().Name}");
 
             foreach (var entityMapType in entityMapTypes)
+            {
                 addMapMethod
                     .MakeGenericMethod(entityMapType.EntityMapInterface.GetGenericArguments())
                     .Invoke(configuration, new[] {Activator.CreateInstance(entityMapType.Type)});
+            }
         }
     }
 }

--- a/src/Dapper.FluentMap/Utils/FluentMapConfigurationExtensions.cs
+++ b/src/Dapper.FluentMap/Utils/FluentMapConfigurationExtensions.cs
@@ -8,7 +8,7 @@ using Dapper.FluentMap.Mapping;
 namespace Dapper.FluentMap.Utils
 {
     /// <summary>
-    /// Extension methods for <see cref="FluentMapConfiguration"/>
+    /// Extension methods for <see cref="FluentMapConfiguration"/>.
     /// </summary>
     public static class FluentMapConfigurationExtensions
     {
@@ -17,11 +17,10 @@ namespace Dapper.FluentMap.Utils
         /// and applies them to <see cref="FluentMapConfiguration"/>,
         /// by calling <see cref="FluentMapConfiguration.AddMap{TEntity}"/> and passing an instance of found type.
         /// </summary>
-        /// <param name="configuration">The <see cref="FluentMapConfiguration"/> instance</param>
-        /// <param name="assemblies">Assemblies</param>
+        /// <param name="configuration">The <see cref="FluentMapConfiguration"/> instance.</param>
+        /// <param name="assemblies">The assemblies to scan for entity maps.</param>
         /// <exception cref="ArgumentNullException"></exception>
-        public static void ApplyMapsFromAssemblies(this FluentMapConfiguration configuration,
-            params Assembly[] assemblies)
+        public static void ApplyMapsFromAssemblies(this FluentMapConfiguration configuration,  params Assembly[] assemblies)
         {
             if (assemblies == null)
                 throw new ArgumentNullException(nameof(assemblies));

--- a/src/Dapper.FluentMap/Utils/FluentMapConfigurationExtensions.cs
+++ b/src/Dapper.FluentMap/Utils/FluentMapConfigurationExtensions.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Dapper.FluentMap.Configuration;
+using Dapper.FluentMap.Mapping;
+
+namespace Dapper.FluentMap.Utils
+{
+    /// <summary>
+    /// Extension methods for <see cref="FluentMapConfiguration"/>
+    /// </summary>
+    public static class FluentMapConfigurationExtensions
+    {
+        /// <summary>
+        /// Finds all types, from provided assemblies, implementing <see cref="EntityMap{TEntity}"/>
+        /// and applies them to <see cref="FluentMapConfiguration"/>,
+        /// by calling <see cref="FluentMapConfiguration.AddMap{TEntity}"/> and passing an instance of found type.
+        /// </summary>
+        /// <param name="configuration">The <see cref="FluentMapConfiguration"/> instance</param>
+        /// <param name="assemblies">Assemblies</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static void ApplyMapsFromAssemblies(this FluentMapConfiguration configuration,
+            params Assembly[] assemblies)
+        {
+            if (assemblies == null)
+                throw new ArgumentNullException(nameof(assemblies));
+
+            var entityMapTypes = FindTypesImplementingIEntityMap(assemblies);
+
+            if (!entityMapTypes.Any())
+                return;
+
+            EnsureNoDuplicateMapping(entityMapTypes);
+
+            AddMaps(configuration, entityMapTypes);
+        }
+
+
+        private static List<(Type Type, Type EntityMapInterface)> FindTypesImplementingIEntityMap(Assembly[] assemblies)
+        {
+            return assemblies
+                .SelectMany(a => a.GetTypes()
+                    .Where(t => !t.IsAbstract && !t.IsInterface)
+                    .Select<Type, (Type Type, Type EntityMapInterface)>(t =>
+                    (
+                        t,
+                        t.GetInterfaces()
+                            .Where(i => i.IsGenericType)
+                            .FirstOrDefault(i => i.GetGenericTypeDefinition() == typeof(IEntityMap<>))
+                    )))
+                .Where(t => t.EntityMapInterface != null)
+                .ToList();
+        }
+
+        private static void EnsureNoDuplicateMapping(List<(Type Type, Type EntityMapInterface)> entityMapTypes)
+        {
+            var typesWithMultipleMappings = entityMapTypes.GroupBy(t => t.EntityMapInterface)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key.GetGenericArguments().First())
+                .ToList();
+
+            if (typesWithMultipleMappings.Any())
+                throw new InvalidOperationException(
+                    $"Multiple mappings defined for types: '{PrintTypeNames(typesWithMultipleMappings)}'");
+        }
+
+        private static string PrintTypeNames(List<Type> multipleMappings)
+            => multipleMappings.Aggregate(string.Empty, (previous, next) => $"{previous}, {next.Name}");
+
+        private static void AddMaps(FluentMapConfiguration configuration,
+            List<(Type Type, Type EntityMapInterface)> entityMapTypes)
+        {
+            var addMapMethod = configuration.GetType().GetMethod(nameof(configuration.AddMap))
+                               ?? throw new InvalidOperationException(
+                                   $"Cannot find {nameof(configuration.AddMap)} method on {configuration.GetType().Name}");
+
+            foreach (var entityMapType in entityMapTypes)
+                addMapMethod
+                    .MakeGenericMethod(entityMapType.EntityMapInterface.GetGenericArguments())
+                    .Invoke(configuration, new[] {Activator.CreateInstance(entityMapType.Type)});
+        }
+    }
+}


### PR DESCRIPTION
@henkmollema I came with this solution when I was using your library while working with Dapper, and wanted to suggest it to you if that might be interesting. The implementation itself is a **FluentMapConfiguration** extension method which gives possibility to automatically discover types implementing **IEntityMap<>** for specific assemblies, so there is no need to add them manually (usually everyone will be inheriting from EntityMap<>, but it is implementing IEntityMap) . Usage:
```c#
FluentMapper.Configure(c => 
{
  c.ApplyMapsFromAssemblies(assemblies); // 
});
```