### PR TITLE
Fix for non generated composite keys

### DIFF
--- a/src/Dapper.FluentMap.Dommel/Mapping/DommelPropertyMap.cs
+++ b/src/Dapper.FluentMap.Dommel/Mapping/DommelPropertyMap.cs
@@ -31,7 +31,7 @@ namespace Dapper.FluentMap.Dommel.Mapping
         /// <summary>
         /// Gets a value indicating how the column is generated.
         /// </summary>
-        public DatabaseGeneratedOption GeneratedOption { get; set; } = DatabaseGeneratedOption.None;
+        public DatabaseGeneratedOption? GeneratedOption { get; set; }
 
         /// <summary>
         /// Specifies the current property as key for the entity.

--- a/src/Dapper.FluentMap.Dommel/Resolvers/DommelKeyPropertyResolver.cs
+++ b/src/Dapper.FluentMap.Dommel/Resolvers/DommelKeyPropertyResolver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
 using Dapper.FluentMap.Dommel.Mapping;
@@ -29,7 +30,7 @@ namespace Dapper.FluentMap.Dommel.Resolvers
                 var allPropertyMaps = entityMap.PropertyMaps.OfType<DommelPropertyMap>();
                 var keyPropertyInfos = allPropertyMaps
                      .Where(e => e.Key)
-                     .Select(x => new ColumnPropertyInfo(x.PropertyInfo, isKey: true))
+                     .Select(x => new ColumnPropertyInfo(x.PropertyInfo, x.GeneratedOption ?? (x.Key ? DatabaseGeneratedOption.Identity : DatabaseGeneratedOption.None)))
                      .ToArray();
 
                 // Now make sure there aren't any missing key properties that weren't explicitly defined in the mapping.

--- a/src/Dapper.FluentMap.Dommel/Resolvers/DommelPropertyResolver.cs
+++ b/src/Dapper.FluentMap.Dommel/Resolvers/DommelPropertyResolver.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Reflection;
 using Dapper.FluentMap.Dommel.Mapping;
@@ -45,7 +46,7 @@ namespace Dapper.FluentMap.Dommel.Resolvers
                         var dommelPropertyMap = propertyMap as DommelPropertyMap;
                         if (dommelPropertyMap != null)
                         {
-                            yield return new ColumnPropertyInfo(property, isKey: dommelPropertyMap.Key);
+                            yield return new ColumnPropertyInfo(property, dommelPropertyMap.GeneratedOption ?? (dommelPropertyMap.Key ? DatabaseGeneratedOption.Identity : DatabaseGeneratedOption.None));
                         }
                         else
                         {

--- a/test/Dapper.FluentMap.Dommel.Tests/ManualMappingTests.cs
+++ b/test/Dapper.FluentMap.Dommel.Tests/ManualMappingTests.cs
@@ -1,5 +1,6 @@
 using Dapper.FluentMap.Dommel.Mapping;
 using System;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using Xunit;
 
@@ -93,6 +94,36 @@ namespace Dapper.FluentMap.Dommel.Tests
 
         }
 
+        [Fact]
+        public void EntityMapsToMultipleKeys()
+        {
+            PreTest();
+
+            FluentMapper.Initialize(c => c.AddMap(new MapCompositeKeyPropertyMap()));
+
+            var type = typeof(CompositeKeyEntity);
+            var keyResolver = new Dommel.Resolvers.DommelKeyPropertyResolver();
+            var keys = keyResolver.ResolveKeyProperties(type);
+
+            Assert.True(keys.Count() == 2);
+            Assert.All(keys, k => Assert.False(k.IsGenerated));
+        }
+
+        [Fact]
+
+        public void PropertiesAreNotGenerated()
+        {
+            PreTest();
+
+            FluentMapper.Initialize(c => c.AddMap(new MapCompositeKeyPropertyMap()));
+
+            var type = typeof(CompositeKeyEntity);
+            var propertyResolver = new Dommel.Resolvers.DommelPropertyResolver();
+            var properties = propertyResolver.ResolveProperties(type);
+
+            Assert.All(properties, p => Assert.False(p.IsGenerated));
+        }
+
         private static void PreTest()
         {
             FluentMapper.EntityMaps.Clear();
@@ -121,6 +152,15 @@ namespace Dapper.FluentMap.Dommel.Tests
             public MapSingleCustomIdDefaultKey()
             {
                 Map(p => p.CustomId).ToColumn("customid", false);
+            }
+        }
+
+        private class MapCompositeKeyPropertyMap : DommelEntityMap<CompositeKeyEntity>
+        {
+            public MapCompositeKeyPropertyMap()
+            {
+                Map(p => p.KeyPartOne).IsKey().SetGeneratedOption(DatabaseGeneratedOption.None);
+                Map(p => p.KeyPartTwo).IsKey().SetGeneratedOption(DatabaseGeneratedOption.None);
             }
         }
     }

--- a/test/Dapper.FluentMap.Dommel.Tests/TestEntity.cs
+++ b/test/Dapper.FluentMap.Dommel.Tests/TestEntity.cs
@@ -30,4 +30,10 @@ namespace Dapper.FluentMap.Dommel.Tests
     {
         public int Id { get; set; }
     }
+
+    public class CompositeKeyEntity
+    {
+        public int KeyPartOne { get; set; }
+        public int KeyPartTwo { get; set; }
+    }
 }


### PR DESCRIPTION
Allows for none generated keys and composite keys.

It uses the same logic found in https://github.com/henkmollema/Dommel/blob/master/src/Dommel/ColumnPropertyInfo.cs#L26

fixes https://github.com/henkmollema/Dapper-FluentMap/issues/122