### PR TITLE
Fix up NotImplementedException when ignore property

### DIFF
--- a/src/Dapper.FluentMap/TypeMaps/MultiTypeMap.cs
+++ b/src/Dapper.FluentMap/TypeMaps/MultiTypeMap.cs
@@ -104,7 +104,7 @@ namespace Dapper.FluentMap.TypeMaps
                     if (result != null)
                     {
 #if !NETSTANDARD1_3
-                        if (result is IgnoredPropertyInfo)
+                        if (result is IgnoredPropertyInfo || result.Property is IgnoredPropertyInfo)
                         {
                             // The property is explicitly ignored, 
                             // return null to prevent falling back to default type map of Dapper.


### PR DESCRIPTION
Hi. I get NotImplementedException when try to use `.Ignore()` at EntityMap. 

Here is example code:
```csharp
class Program
    {
        static async Task Main(string[] args)
        {
            var connectionString = "User ID=pt_system;Password=P@ssw0rdP@ssw0rd;Host=localhost;Port=5432;Database=dapper_poc;Pooling=true;Maximum Pool Size=200;Application Name=Dapper Poc;";
            var fixture = new Fixture();
            
            FluentMapper.Initialize(cfg =>
            {
                cfg.AddMap(new BarMap());
            });
            
            await using (var connection = new NpgsqlConnection(connectionString))
            {
                await connection.OpenAsync();
                await connection.ExecuteAsync(new CommandDefinition(
                    "CREATE TABLE IF NOT EXISTS Bar (Id SERIAL PRIMARY KEY, Description varchar(255), Status varchar(255))"));
                await connection.ExecuteAsync(new CommandDefinition(
                    $"INSERT INTO Bar(Description, Status) VALUES('{fixture.Create<string>()}', '{fixture.Create<string>()}');"));
                await connection.CloseAsync();
            }

            await using (var connection = new NpgsqlConnection(connectionString))
            {
                await connection.OpenAsync();
                var bar = await connection.QueryAsync<Bar>("select * from Bar");
                connection.CloseAsync();
            }
        }
    }

    public class BarMap : EntityMap<Bar>
    {
        public BarMap()
        {
            Map(it => it.Status).Ignore();
        }
    }
    

    public class Bar
    {
        public int Id { get; }
        public string Description { get; }
        public string Status { get; }
    }
```
Stack trace:
```
System.NotImplementedException: The method or operation is not implemented.
   at Dapper.FluentMap.TypeMaps.IgnoredPropertyInfo.get_PropertyType()
   at Dapper.SimpleMemberMap.get_MemberType() in C:\Users\nponomarev\Documents\Repos\Dapper\Dapper\SimpleMemberMap.cs:line 52
   at Dapper.SqlMapper.GenerateDeserializerFromMap(Type type, IDataReader reader, Int32 startBound, Int32 length, Boolean returnNullIfFirstMissing, ILGenerator il) in C:\Users\nponomarev\Documents\Repos\Dapper\Dapper\SqlMapper.cs:line 3331
   at Dapper.SqlMapper.GetTypeDeserializerImpl(Type type, IDataReader reader, Int32 startBound, Int32 length, Boolean returnNullIfFirstMissing) in C:\Users\nponomarev\Documents\Repos\Dapper\Dapper\SqlMapper.cs:line 3117
   at Dapper.SqlMapper.TypeDeserializerCache.GetReader(IDataReader reader, Int32 startBound, Int32 length, Boolean returnNullIfFirstMissing) in C:\Users\nponomarev\Documents\Repos\Dapper\Dapper\SqlMapper.TypeDeserializerCache.cs:line 151
   at Dapper.SqlMapper.TypeDeserializerCache.GetReader(Type type, IDataReader reader, Int32 startBound, Int32 length, Boolean returnNullIfFirstMissing) in C:\Users\nponomarev\Documents\Repos\Dapper\Dapper\SqlMapper.TypeDeserializerCache.cs:line 50
   at Dapper.SqlMapper.GetTypeDeserializer(Type type, IDataReader reader, Int32 startBound, Int32 length, Boolean returnNullIfFirstMissing) in C:\Users\nponomarev\Documents\Repos\Dapper\Dapper\SqlMapper.cs:line 3071
   at Dapper.SqlMapper.GetDeserializer(Type type, IDataReader reader, Int32 startBound, Int32 length, Boolean returnNullIfFirstMissing) in C:\Users\nponomarev\Documents\Repos\Dapper\Dapper\SqlMapper.cs:line 1824
   at Dapper.SqlMapper.QueryAsync[T](IDbConnection cnn, Type effectiveType, CommandDefinition command) in C:\Users\nponomarev\Documents\Repos\Dapper\Dapper\SqlMapper.Async.cs:line 426
   at DapperPoc.Program.Main(String[] args) in C:\Users\nponomarev\Documents\Repos\DapperPoc\DapperPoc\Program.cs:line 35
   at DapperPoc.Program.Main(String[] args) in C:\Users\nponomarev\Documents\Repos\DapperPoc\DapperPoc\Program.cs:line 37
   at DapperPoc.Program.<Main>(String[] args)
```